### PR TITLE
左右キーの入れ替え設定をテキスト画面にも反映

### DIFF
--- a/app/src/main/java/src/comitton/activity/TextActivity.java
+++ b/app/src/main/java/src/comitton/activity/TextActivity.java
@@ -192,6 +192,7 @@ public class TextActivity extends Activity implements OnTouchListener, Handler.C
 	private boolean mNotice;
 	private boolean mNoSleep;
 	private boolean mChgPage;
+	private boolean mChgPageKey;
 	private boolean mChgFlick;
 	private boolean mConfirmBack;
 	private boolean mCMargin;
@@ -726,14 +727,24 @@ public class TextActivity extends Activity implements OnTouchListener, Handler.C
 			switch (code) {
 				case KeyEvent.KEYCODE_DPAD_RIGHT:
 				{
-					// 次ページへ
-					nextPage();
+					if (mChgPageKey) {
+						// 前ページへ
+						prevPage();
+					} else {
+						// 次ページへ
+						nextPage();
+					}
 					break;
 				}
 				case KeyEvent.KEYCODE_DPAD_LEFT:
 				{
-					// 前ページへ
-					prevPage();
+					if (mChgPageKey) {
+						// 次ページへ
+						nextPage();
+					} else {
+						// 前ページへ
+						prevPage();
+					}
 					break;
 				}
 				case KeyEvent.KEYCODE_MENU:
@@ -2381,6 +2392,7 @@ public class TextActivity extends Activity implements OnTouchListener, Handler.C
 		mTopColor2 = 0x40000000 | (mTopColor1 & 0x00FFFFFF);
 
 		mChgPage = SetImageText.getChgPage(sharedPreferences);
+		mChgPageKey = SetImageText.getChgPageKey(sharedPreferences);
 		mChgFlick = SetImageText.getChgFlick(sharedPreferences);
 		mLastMsg = SetImageText.getLastPage(sharedPreferences);
 		// mSavePage = false;// SetImageText.getSavePage(sharedPreferences);

--- a/app/src/main/res/xml-ja/text.xml
+++ b/app/src/main/res/xml-ja/text.xml
@@ -185,6 +185,11 @@
             android:key="txPageSelect"
             android:summary="dummy"
             android:title="ページ選択方法" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="ChgPageKey"
+            android:summary="チェックにより右キーが前ページの移動になります"
+            android:title="左右キー操作の入替え＊" />
     </PreferenceCategory>
     <PreferenceCategory android:title="サイズ設定" >
         <src.comitton.config.TextFontTopSeekbar

--- a/app/src/main/res/xml/text.xml
+++ b/app/src/main/res/xml/text.xml
@@ -185,6 +185,11 @@
             android:key="txPageSelect"
             android:summary="dummy"
             android:title="Page select operation(*)" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="ChgPageKey"
+            android:summary="When checked, right key will move to the previous page."
+            android:title="Swap the LR key operation(*)" />
     </PreferenceCategory>
     <PreferenceCategory android:title="Size Settings" >
         <src.comitton.config.TextFontTopSeekbar


### PR DESCRIPTION
タップの入れ替えと同様にイメージ画面だけでなくテキスト画面でも共通で設定、操作出来るようにする